### PR TITLE
Add GitHub Actions workflow to build and deploy site to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,60 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build site
+        run: yarn build
+
+      - name: Add custom domain
+        run: echo "mikeholmdev.com" > dist/CNAME
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Automate building and publishing the static site to GitHub Pages on `push` to `master` and via manual `workflow_dispatch`.
- Ensure the site is built with Node 20 and Yarn and published with a custom domain `mikeholmdev.com`.

### Description
- Added `.github/workflows/pages.yml` to define a two-job workflow `build` and `deploy` for GitHub Pages deployment.
- The `build` job checks out the repo, sets up Node (`20`) with `actions/setup-node@v4`, installs with `yarn install --frozen-lockfile`, runs `yarn build`, and writes `dist/CNAME` with `mikeholmdev.com` before uploading the `dist` artifact via `actions/upload-pages-artifact@v3`.
- The `deploy` job runs after `build`, sets the `github-pages` environment and deploys using `actions/deploy-pages@v4` with proper `pages` and `id-token` permissions configured.
- Workflow-level `concurrency` and minimal `contents: read`/`pages: write` permissions are configured to control runs and permissions.

### Testing
- No automated unit or integration tests were added or modified in this change.
- The new workflow file has not been executed as part of this PR, so there are no CI run results to report.
- Syntax and runtime validation of the workflow will occur on the first GitHub Actions run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a336625a7a8832e93baeda6427e715b)