### PR TITLE
Remove current work overview copy

### DIFF
--- a/src/portfolio.js
+++ b/src/portfolio.js
@@ -219,21 +219,6 @@ const currentWork = () =>
       { class: 'section-heading' },
       H.p({ class: 'eyebrow' }, 'Current work'),
       H.h2('Percipient.ai')
-    ),
-    H.div(
-      { class: 'role-layout' },
-      H.p(
-        { class: 'role-meta' },
-        'Principal UI Engineer, Tech Lead, 2020-present'
-      ),
-      H.div(
-        H.p(
-          'Percipient.ai builds Mirage, an intelligence analysis platform for national security missions. My portfolio should handle this work differently from a resume: some details need to stay high-level, but the product context and engineering shape still matter.'
-        ),
-        H.p(
-          'This section is intentionally framed as a placeholder for deeper, approved writeups about complex product work, AI-assisted workflows, data-heavy interfaces, and engineering decisions made under real operational constraints.'
-        )
-      )
     )
   )
 
@@ -245,7 +230,7 @@ const identityUploadWorkflow = () =>
     { class: 'case-study percipient-case-study', id: 'identity-image-upload' },
     H.div(
       { class: 'section-heading' },
-      H.p({ class: 'eyebrow' }, 'Percipient deep dive sketch'),
+      H.p({ class: 'eyebrow' }, 'Percipient deep dive'),
       H.h2('Bulk image upload for identity creation')
     ),
     H.div(
@@ -354,7 +339,7 @@ const resultsMapWorkflow = () =>
     { class: 'case-study percipient-case-study', id: 'results-map' },
     H.div(
       { class: 'section-heading' },
-      H.p({ class: 'eyebrow' }, 'Percipient deep dive sketch'),
+      H.p({ class: 'eyebrow' }, 'Percipient deep dive'),
       H.h2('Maps for search result exploration')
     ),
     H.div(
@@ -442,7 +427,7 @@ const libraryScalability = () =>
     { class: 'case-study percipient-case-study', id: 'library-scalability' },
     H.div(
       { class: 'section-heading' },
-      H.p({ class: 'eyebrow' }, 'Percipient deep dive sketch'),
+      H.p({ class: 'eyebrow' }, 'Percipient deep dive'),
       H.h2('Refactoring the library for scale and navigation')
     ),
     H.div(


### PR DESCRIPTION
### Motivation
- Remove the overview/placeholder prose in the "Current work" section so the portfolio no longer contains framing language or placeholder copy about Percipient.ai / Mirage while preserving the detailed case studies. 
- Keep the section anchor so navigation to `#current-work` still resolves and the deep dives remain grouped under the same heading.
- Ensure the first deep dive still contains the Mirage entry sentence so a cold reader retains minimal product context.

### Description
- Deleted the overview paragraphs from the `currentWork` component, leaving a bare section heading with `id="current-work"` and the eyebrow/heading intact. 
- Updated the per-case-study eyebrow labels from `'Percipient deep dive sketch'` to `'Percipient deep dive'` for the three Percipient case studies. 
- Did not modify the three deep-dive case studies themselves, their role labels, ordering, or any other site sections or styles.

### Testing
- Ran `yarn build` and it completed successfully with no new build warnings. 
- Ran `yarn test` and the lint-based tests completed successfully. 
- Attempted the project `serve:dev` script (`yarn serve:dev`), which failed under the container/Corepack environment, so I served the built output with `python3 -m http.server 8000 --directory dist` instead. 
- Verified the rendered site programmatically against `http://127.0.0.1:8000/` to confirm `#current-work` exists, the nav still links to `#current-work` with the same label and order, all three deep dives render in order and unmodified, the Mirage entry sentence is present in the first deep dive, and no `placeholder`/`sketch` text remains; these checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37633a48ac832e80435e504bca3d87)